### PR TITLE
Add hego.red to Understanding Prompt Injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Key attack vectors in AI/ML systems:
 - [Bugcrowd — AI Vulnerability Deep Dive: Prompt Injection](https://www.bugcrowd.com/blog/ai-vulnerability-deep-dive-prompt-injection/)
 - [Prompt Injection Cheat Sheet — Seclify](https://blog.seclify.com/prompt-injection-cheat-sheet/) — Practical cheat sheet for AI bot integrations
 - [Don't You (Forget NLP) — Dropbox Tech](https://dropbox.tech/machine-learning/prompt-injection-with-control-characters-openai-chatgpt-llm) — Injection via control characters
+- [hego.red - Practical AI/LLM Red Teaming Notes](https://hego.red/) - Hands-on guide: prompt injection, jailbreaks, indirect injection, RAG poisoning, agent and tool attacks, with a full methodology and worked labs
 
 ### 3.2 Jailbreaking Techniques
 


### PR DESCRIPTION
Adds **hego.red**, a free single-page practical guide to AI/LLM red teaming: prompt injection, jailbreaks, indirect injection, RAG poisoning, agent and tool attacks, a full methodology mapped to the OWASP LLM Top 10 and MITRE ATLAS, plus worked labs. No ads, no tracking, no signup.

Added under **3.1 Understanding Prompt Injection**. Thanks for maintaining this roadmap.